### PR TITLE
Use `bool` and `int` instead of `boolean` and `integer`

### DIFF
--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -2024,13 +2024,13 @@ class PHP_CodeSniffer
         } else {
             $lowerVarType = strtolower($varType);
             switch ($lowerVarType) {
-            case 'bool':
-                return 'boolean';
+            case 'boolean':
+                return 'bool';
             case 'double':
             case 'real':
                 return 'float';
-            case 'int':
-                return 'integer';
+            case 'integer':
+                return 'int';
             case 'array()':
                 return 'array';
             }//end switch

--- a/CodeSniffer.php
+++ b/CodeSniffer.php
@@ -184,9 +184,9 @@ class PHP_CodeSniffer
      */
     public static $allowedTypes = array(
                                    'array',
-                                   'boolean',
+                                   'bool',
                                    'float',
-                                   'integer',
+                                   'int',
                                    'mixed',
                                    'object',
                                    'string',


### PR DESCRIPTION
Per https://wiki.php.net/rfc/scalar_type_hints_v5 PHP7 uses `bool` and `int` as aliases are removed. However https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer.php#L2079 causes `bool` to be `boolean` and `int` to be `integer`

Can this be changed to reflect the actual correct values rather than the aliases?

Thanks
